### PR TITLE
chore(biome): lint & formatter 설정 및 적용

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+	"editor.defaultFormatter": "biomejs.biome"
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,6 @@
 {
+	"editor.codeActionsOnSave": {
+		"source.organizeImports.biome": "explicit"
+	},
 	"editor.defaultFormatter": "biomejs.biome"
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,6 @@
 {
-	"editor.codeActionsOnSave": {
-		"source.organizeImports.biome": "explicit"
-	},
-	"editor.defaultFormatter": "biomejs.biome"
+  "editor.codeActionsOnSave": {
+    "source.organizeImports.biome": "explicit"
+  },
+  "editor.defaultFormatter": "biomejs.biome"
 }

--- a/biome.json
+++ b/biome.json
@@ -1,0 +1,39 @@
+{
+	"$schema": "https://biomejs.dev/schemas/1.9.2/schema.json",
+	"vcs": {
+		"enabled": false,
+		"clientKind": "git",
+		"useIgnoreFile": false
+	},
+	"files": {
+		"ignoreUnknown": false,
+		"ignore": []
+	},
+	"formatter": {
+		"enabled": true,
+		"indentStyle": "tab",
+		"indentWidth": 2,
+		"lineWidth": 100,
+		"lineEnding": "lf"
+	},
+	"organizeImports": {
+		"enabled": true
+	},
+	"linter": {
+		"enabled": true,
+		"rules": {
+			"recommended": true
+		}
+	},
+	"javascript": {
+		"formatter": {
+			"quoteStyle": "single",
+			"semicolons": "asNeeded"
+		}
+	},
+	"json": {
+		"formatter": {
+			"trailingCommas": "none"
+		}
+	}
+}

--- a/biome.json
+++ b/biome.json
@@ -7,7 +7,7 @@
 	},
 	"files": {
 		"ignoreUnknown": false,
-		"ignore": []
+		"ignore": ["dist/**/*", "node_modules/**/*"]
 	},
 	"formatter": {
 		"enabled": true,

--- a/biome.json
+++ b/biome.json
@@ -1,39 +1,39 @@
 {
-	"$schema": "https://biomejs.dev/schemas/1.9.2/schema.json",
-	"vcs": {
-		"enabled": false,
-		"clientKind": "git",
-		"useIgnoreFile": false
-	},
-	"files": {
-		"ignoreUnknown": false,
-		"ignore": ["dist/**/*", "node_modules/**/*"]
-	},
-	"formatter": {
-		"enabled": true,
-		"indentStyle": "tab",
-		"indentWidth": 2,
-		"lineWidth": 100,
-		"lineEnding": "lf"
-	},
-	"organizeImports": {
-		"enabled": true
-	},
-	"linter": {
-		"enabled": true,
-		"rules": {
-			"recommended": true
-		}
-	},
-	"javascript": {
-		"formatter": {
-			"quoteStyle": "single",
-			"semicolons": "asNeeded"
-		}
-	},
-	"json": {
-		"formatter": {
-			"trailingCommas": "none"
-		}
-	}
+  "$schema": "https://biomejs.dev/schemas/1.9.2/schema.json",
+  "vcs": {
+    "enabled": false,
+    "clientKind": "git",
+    "useIgnoreFile": false
+  },
+  "files": {
+    "ignoreUnknown": false,
+    "ignore": ["dist/**/*", "node_modules/**/*"]
+  },
+  "formatter": {
+    "enabled": true,
+    "indentStyle": "space",
+    "indentWidth": 2,
+    "lineWidth": 100,
+    "lineEnding": "lf"
+  },
+  "organizeImports": {
+    "enabled": true
+  },
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "recommended": true
+    }
+  },
+  "javascript": {
+    "formatter": {
+      "quoteStyle": "single",
+      "semicolons": "asNeeded"
+    }
+  },
+  "json": {
+    "formatter": {
+      "trailingCommas": "none"
+    }
+  }
 }

--- a/manifest.json
+++ b/manifest.json
@@ -1,41 +1,41 @@
 {
-	"name": "Floating Table of Contents",
-	"description": "Explore documents with ease and float your ToC anywhere!",
-	"version": "1.0",
-	"manifest_version": 3,
-	"permissions": ["activeTab"],
-	"action": {
-		"default_icon": {
-			"16": "images/table-16.png",
-			"32": "images/table-32.png",
-			"48": "images/table-48.png",
-			"128": "images/table-128.png"
-		}
-	},
-	"content_scripts": [
-		{
-			"js": ["contentScript/index.js"],
-			"css": ["contentScript/index.css"],
-			"matches": ["https://*/*", "http://localhost/*"]
-		}
-	],
-	"background": {
-		"service_worker": "background/index.js",
-		"type": "module"
-	},
-	"icons": {
-		"16": "images/table-16.png",
-		"32": "images/table-32.png",
-		"48": "images/table-48.png",
-		"128": "images/table-128.png"
-	},
-	"commands": {
-		"_execute_action": {
-			"suggested_key": {
-				"default": "Ctrl+B",
-				"mac": "Command+B"
-			},
-			"description": "Floating Table of Contents"
-		}
-	}
+  "name": "Floating Table of Contents",
+  "description": "Explore documents with ease and float your ToC anywhere!",
+  "version": "1.0",
+  "manifest_version": 3,
+  "permissions": ["activeTab"],
+  "action": {
+    "default_icon": {
+      "16": "images/table-16.png",
+      "32": "images/table-32.png",
+      "48": "images/table-48.png",
+      "128": "images/table-128.png"
+    }
+  },
+  "content_scripts": [
+    {
+      "js": ["contentScript/index.js"],
+      "css": ["contentScript/index.css"],
+      "matches": ["https://*/*", "http://localhost/*"]
+    }
+  ],
+  "background": {
+    "service_worker": "background/index.js",
+    "type": "module"
+  },
+  "icons": {
+    "16": "images/table-16.png",
+    "32": "images/table-32.png",
+    "48": "images/table-48.png",
+    "128": "images/table-128.png"
+  },
+  "commands": {
+    "_execute_action": {
+      "suggested_key": {
+        "default": "Ctrl+B",
+        "mac": "Command+B"
+      },
+      "description": "Floating Table of Contents"
+    }
+  }
 }

--- a/manifest.json
+++ b/manifest.json
@@ -1,50 +1,41 @@
 {
-  "name": "Floating Table of Contents",
-  "description": "Explore documents with ease and float your ToC anywhere!",
-  "version": "1.0",
-  "manifest_version": 3,
-  "permissions": [
-    "activeTab"
-  ],
-  "action": {
-    "default_icon": {
-      "16": "images/table-16.png",
-      "32": "images/table-32.png",
-      "48": "images/table-48.png",
-      "128": "images/table-128.png"
-    }
-  },
-  "content_scripts": [
-    {
-      "js": [
-        "contentScript/index.js"
-      ],
-      "css": [
-        "contentScript/index.css"
-      ],
-      "matches": [
-        "https://*/*",
-        "http://localhost/*"
-      ]
-    }
-  ],
-  "background": {
-    "service_worker": "background/index.js",
-    "type": "module"
-  },
-  "icons": {
-    "16": "images/table-16.png",
-    "32": "images/table-32.png",
-    "48": "images/table-48.png",
-    "128": "images/table-128.png"
-  },
-   "commands": {
-    "_execute_action": {
-      "suggested_key": {
-        "default": "Ctrl+B",
-        "mac": "Command+B"
-      },
-      "description": "Floating Table of Contents"
-    }
-  }
+	"name": "Floating Table of Contents",
+	"description": "Explore documents with ease and float your ToC anywhere!",
+	"version": "1.0",
+	"manifest_version": 3,
+	"permissions": ["activeTab"],
+	"action": {
+		"default_icon": {
+			"16": "images/table-16.png",
+			"32": "images/table-32.png",
+			"48": "images/table-48.png",
+			"128": "images/table-128.png"
+		}
+	},
+	"content_scripts": [
+		{
+			"js": ["contentScript/index.js"],
+			"css": ["contentScript/index.css"],
+			"matches": ["https://*/*", "http://localhost/*"]
+		}
+	],
+	"background": {
+		"service_worker": "background/index.js",
+		"type": "module"
+	},
+	"icons": {
+		"16": "images/table-16.png",
+		"32": "images/table-32.png",
+		"48": "images/table-48.png",
+		"128": "images/table-128.png"
+	},
+	"commands": {
+		"_execute_action": {
+			"suggested_key": {
+				"default": "Ctrl+B",
+				"mac": "Command+B"
+			},
+			"description": "Floating Table of Contents"
+		}
+	}
 }

--- a/package.json
+++ b/package.json
@@ -1,41 +1,41 @@
 {
-	"name": "floating-table-of-contents",
-	"version": "1.0.0",
-	"description": "Explore documents with ease and float your ToC anywhere!",
-	"main": "index.js",
-	"type": "module",
-	"scripts": {
-		"dev": "concurrently -p \"[{name}]\" -n \"vite,tsc,nodemon\" -c \"bgGreen.bold,bgBlue.bold,bgMagenta.bold\" \"pnpm watch:contentScript\" \"pnpm watch:ts\" \"pnpm watch:static\"",
-		"watch:contentScript": "vite build --watch",
-		"watch:ts": "tsc --watch",
-		"copy:manifest": "copyfiles manifest.json dist/",
-		"copy:html": "copyfiles -u -2 src/**/*.html dist/",
-		"copy:images": "copyfiles -u -2 src/**/*.png dist/",
-		"copy:all": "pnpm copy:manifest && pnpm copy:html && pnpm copy:images",
-		"watch:static": "nodemon --watch ./ --ignore dist/ --ignore node_modules/ --ext html,css,json,png --exec \"pnpm copy:all\"",
-		"build:prod": "pnpm copy:all && vite build && tsc --build --force"
-	},
-	"author": "",
-	"license": "MIT",
-	"devDependencies": {
-		"@biomejs/biome": "^1.9.2",
-		"@types/chrome": "^0.0.270",
-		"@types/node": "^22.5.5",
-		"@types/react": "^18.3.8",
-		"@types/react-dom": "^18.3.0",
-		"@vitejs/plugin-react": "^4.3.1",
-		"concurrently": "^9.0.1",
-		"copyfiles": "^2.4.1",
-		"nodemon": "^3.1.4",
-		"typescript": "^5.6.2",
-		"vite": "^5.4.7"
-	},
-	"dependencies": {
-		"autoprefixer": "^10.4.20",
-		"framer-motion": "^11.5.6",
-		"postcss": "^8.4.47",
-		"react": "^18.3.1",
-		"react-dom": "^18.3.1",
-		"tailwindcss": "^3.4.12"
-	}
+  "name": "floating-table-of-contents",
+  "version": "1.0.0",
+  "description": "Explore documents with ease and float your ToC anywhere!",
+  "main": "index.js",
+  "type": "module",
+  "scripts": {
+    "dev": "concurrently -p \"[{name}]\" -n \"vite,tsc,nodemon\" -c \"bgGreen.bold,bgBlue.bold,bgMagenta.bold\" \"pnpm watch:contentScript\" \"pnpm watch:ts\" \"pnpm watch:static\"",
+    "watch:contentScript": "vite build --watch",
+    "watch:ts": "tsc --watch",
+    "copy:manifest": "copyfiles manifest.json dist/",
+    "copy:html": "copyfiles -u -2 src/**/*.html dist/",
+    "copy:images": "copyfiles -u -2 src/**/*.png dist/",
+    "copy:all": "pnpm copy:manifest && pnpm copy:html && pnpm copy:images",
+    "watch:static": "nodemon --watch ./ --ignore dist/ --ignore node_modules/ --ext html,css,json,png --exec \"pnpm copy:all\"",
+    "build:prod": "pnpm copy:all && vite build && tsc --build --force"
+  },
+  "author": "",
+  "license": "MIT",
+  "devDependencies": {
+    "@biomejs/biome": "^1.9.2",
+    "@types/chrome": "^0.0.270",
+    "@types/node": "^22.5.5",
+    "@types/react": "^18.3.8",
+    "@types/react-dom": "^18.3.0",
+    "@vitejs/plugin-react": "^4.3.1",
+    "concurrently": "^9.0.1",
+    "copyfiles": "^2.4.1",
+    "nodemon": "^3.1.4",
+    "typescript": "^5.6.2",
+    "vite": "^5.4.7"
+  },
+  "dependencies": {
+    "autoprefixer": "^10.4.20",
+    "framer-motion": "^11.5.6",
+    "postcss": "^8.4.47",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
+    "tailwindcss": "^3.4.12"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -1,40 +1,41 @@
 {
-  "name": "floating-table-of-contents",
-  "version": "1.0.0",
-  "description": "Explore documents with ease and float your ToC anywhere!",
-  "main": "index.js",
-  "type": "module",
-  "scripts": {
-    "dev": "concurrently -p \"[{name}]\" -n \"vite,tsc,nodemon\" -c \"bgGreen.bold,bgBlue.bold,bgMagenta.bold\" \"pnpm watch:contentScript\" \"pnpm watch:ts\" \"pnpm watch:static\"",
-    "watch:contentScript": "vite build --watch",
-    "watch:ts": "tsc --watch",
-    "copy:manifest": "copyfiles manifest.json dist/",
-    "copy:html": "copyfiles -u -2 src/**/*.html dist/",
-    "copy:images": "copyfiles -u -2 src/**/*.png dist/",
-    "copy:all": "pnpm copy:manifest && pnpm copy:html && pnpm copy:images",
-    "watch:static": "nodemon --watch ./ --ignore dist/ --ignore node_modules/ --ext html,css,json,png --exec \"pnpm copy:all\"",
-    "build:prod": "pnpm copy:all && vite build && tsc --build --force"
-  },
-  "author": "",
-  "license": "MIT",
-  "devDependencies": {
-    "@types/chrome": "^0.0.270",
-    "@types/node": "^22.5.5",
-    "@types/react": "^18.3.8",
-    "@types/react-dom": "^18.3.0",
-    "@vitejs/plugin-react": "^4.3.1",
-    "concurrently": "^9.0.1",
-    "copyfiles": "^2.4.1",
-    "nodemon": "^3.1.4",
-    "typescript": "^5.6.2",
-    "vite": "^5.4.7"
-  },
-  "dependencies": {
-    "autoprefixer": "^10.4.20",
-    "framer-motion": "^11.5.6",
-    "postcss": "^8.4.47",
-    "react": "^18.3.1",
-    "react-dom": "^18.3.1",
-    "tailwindcss": "^3.4.12"
-  }
+	"name": "floating-table-of-contents",
+	"version": "1.0.0",
+	"description": "Explore documents with ease and float your ToC anywhere!",
+	"main": "index.js",
+	"type": "module",
+	"scripts": {
+		"dev": "concurrently -p \"[{name}]\" -n \"vite,tsc,nodemon\" -c \"bgGreen.bold,bgBlue.bold,bgMagenta.bold\" \"pnpm watch:contentScript\" \"pnpm watch:ts\" \"pnpm watch:static\"",
+		"watch:contentScript": "vite build --watch",
+		"watch:ts": "tsc --watch",
+		"copy:manifest": "copyfiles manifest.json dist/",
+		"copy:html": "copyfiles -u -2 src/**/*.html dist/",
+		"copy:images": "copyfiles -u -2 src/**/*.png dist/",
+		"copy:all": "pnpm copy:manifest && pnpm copy:html && pnpm copy:images",
+		"watch:static": "nodemon --watch ./ --ignore dist/ --ignore node_modules/ --ext html,css,json,png --exec \"pnpm copy:all\"",
+		"build:prod": "pnpm copy:all && vite build && tsc --build --force"
+	},
+	"author": "",
+	"license": "MIT",
+	"devDependencies": {
+		"@biomejs/biome": "^1.9.2",
+		"@types/chrome": "^0.0.270",
+		"@types/node": "^22.5.5",
+		"@types/react": "^18.3.8",
+		"@types/react-dom": "^18.3.0",
+		"@vitejs/plugin-react": "^4.3.1",
+		"concurrently": "^9.0.1",
+		"copyfiles": "^2.4.1",
+		"nodemon": "^3.1.4",
+		"typescript": "^5.6.2",
+		"vite": "^5.4.7"
+	},
+	"dependencies": {
+		"autoprefixer": "^10.4.20",
+		"framer-motion": "^11.5.6",
+		"postcss": "^8.4.47",
+		"react": "^18.3.1",
+		"react-dom": "^18.3.1",
+		"tailwindcss": "^3.4.12"
+	}
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,6 +27,9 @@ importers:
         specifier: ^3.4.12
         version: 3.4.12
     devDependencies:
+      '@biomejs/biome':
+        specifier: ^1.9.2
+        version: 1.9.2
       '@types/chrome':
         specifier: ^0.0.270
         version: 0.0.270
@@ -154,6 +157,59 @@ packages:
   '@babel/types@7.25.6':
     resolution: {integrity: sha512-/l42B1qxpG6RdfYf343Uw1vmDjeNhneUXtzhojE7pDgfpEypmRhI6j1kr17XCVv4Cgl9HdAiQY2x0GwKm7rWCw==}
     engines: {node: '>=6.9.0'}
+
+  '@biomejs/biome@1.9.2':
+    resolution: {integrity: sha512-4j2Gfwft8Jqp1X0qLYvK4TEy4xhTo4o6rlvJPsjPeEame8gsmbGQfOPBkw7ur+7/Z/f0HZmCZKqbMvR7vTXQYQ==}
+    engines: {node: '>=14.21.3'}
+    hasBin: true
+
+  '@biomejs/cli-darwin-arm64@1.9.2':
+    resolution: {integrity: sha512-rbs9uJHFmhqB3Td0Ro+1wmeZOHhAPTL3WHr8NtaVczUmDhXkRDWScaxicG9+vhSLj1iLrW47itiK6xiIJy6vaA==}
+    engines: {node: '>=14.21.3'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@biomejs/cli-darwin-x64@1.9.2':
+    resolution: {integrity: sha512-BlfULKijNaMigQ9GH9fqJVt+3JTDOSiZeWOQtG/1S1sa8Lp046JHG3wRJVOvekTPL9q/CNFW1NVG8J0JN+L1OA==}
+    engines: {node: '>=14.21.3'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@biomejs/cli-linux-arm64-musl@1.9.2':
+    resolution: {integrity: sha512-ZATvbUWhNxegSALUnCKWqetTZqrK72r2RsFD19OK5jXDj/7o1hzI1KzDNG78LloZxftrwr3uI9SqCLh06shSZw==}
+    engines: {node: '>=14.21.3'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@biomejs/cli-linux-arm64@1.9.2':
+    resolution: {integrity: sha512-T8TJuSxuBDeQCQzxZu2o3OU4eyLumTofhCxxFd3+aH2AEWVMnH7Z/c3QP1lHI5RRMBP9xIJeMORqDQ5j+gVZzw==}
+    engines: {node: '>=14.21.3'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@biomejs/cli-linux-x64-musl@1.9.2':
+    resolution: {integrity: sha512-CjPM6jT1miV5pry9C7qv8YJk0FIZvZd86QRD3atvDgfgeh9WQU0k2Aoo0xUcPdTnoz0WNwRtDicHxwik63MmSg==}
+    engines: {node: '>=14.21.3'}
+    cpu: [x64]
+    os: [linux]
+
+  '@biomejs/cli-linux-x64@1.9.2':
+    resolution: {integrity: sha512-T0cPk3C3Jr2pVlsuQVTBqk2qPjTm8cYcTD9p/wmR9MeVqui1C/xTVfOIwd3miRODFMrJaVQ8MYSXnVIhV9jTjg==}
+    engines: {node: '>=14.21.3'}
+    cpu: [x64]
+    os: [linux]
+
+  '@biomejs/cli-win32-arm64@1.9.2':
+    resolution: {integrity: sha512-2x7gSty75bNIeD23ZRPXyox6Z/V0M71ObeJtvQBhi1fgrvPdtkEuw7/0wEHg6buNCubzOFuN9WYJm6FKoUHfhg==}
+    engines: {node: '>=14.21.3'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@biomejs/cli-win32-x64@1.9.2':
+    resolution: {integrity: sha512-JC3XvdYcjmu1FmAehVwVV0SebLpeNTnO2ZaMdGCSOdS7f8O9Fq14T2P1gTG1Q29Q8Dt1S03hh0IdVpIZykOL8g==}
+    engines: {node: '>=14.21.3'}
+    cpu: [x64]
+    os: [win32]
 
   '@esbuild/aix-ppc64@0.21.5':
     resolution: {integrity: sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==}
@@ -1348,6 +1404,41 @@ snapshots:
       '@babel/helper-string-parser': 7.24.8
       '@babel/helper-validator-identifier': 7.24.7
       to-fast-properties: 2.0.0
+
+  '@biomejs/biome@1.9.2':
+    optionalDependencies:
+      '@biomejs/cli-darwin-arm64': 1.9.2
+      '@biomejs/cli-darwin-x64': 1.9.2
+      '@biomejs/cli-linux-arm64': 1.9.2
+      '@biomejs/cli-linux-arm64-musl': 1.9.2
+      '@biomejs/cli-linux-x64': 1.9.2
+      '@biomejs/cli-linux-x64-musl': 1.9.2
+      '@biomejs/cli-win32-arm64': 1.9.2
+      '@biomejs/cli-win32-x64': 1.9.2
+
+  '@biomejs/cli-darwin-arm64@1.9.2':
+    optional: true
+
+  '@biomejs/cli-darwin-x64@1.9.2':
+    optional: true
+
+  '@biomejs/cli-linux-arm64-musl@1.9.2':
+    optional: true
+
+  '@biomejs/cli-linux-arm64@1.9.2':
+    optional: true
+
+  '@biomejs/cli-linux-x64-musl@1.9.2':
+    optional: true
+
+  '@biomejs/cli-linux-x64@1.9.2':
+    optional: true
+
+  '@biomejs/cli-win32-arm64@1.9.2':
+    optional: true
+
+  '@biomejs/cli-win32-x64@1.9.2':
+    optional: true
 
   '@esbuild/aix-ppc64@0.21.5':
     optional: true

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,6 +1,6 @@
 export default {
-  plugins: {
-    tailwindcss: {},
-    autoprefixer: {},
-  },
+	plugins: {
+		tailwindcss: {},
+		autoprefixer: {},
+	},
 }

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,6 +1,6 @@
 export default {
-	plugins: {
-		tailwindcss: {},
-		autoprefixer: {},
-	},
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
 }

--- a/src/background/event.ts
+++ b/src/background/event.ts
@@ -1,24 +1,24 @@
 chrome.runtime.onInstalled.addListener(() => {
-	chrome.action.setBadgeBackgroundColor({ color: '#f4fb04' })
-	chrome.action.setBadgeText({ text: '' })
+  chrome.action.setBadgeBackgroundColor({ color: '#f4fb04' })
+  chrome.action.setBadgeText({ text: '' })
 })
 
 chrome.action.onClicked.addListener(async (tab) => {
-	if (!tab.url?.startsWith('http') || !tab.id) {
-		return
-	}
+  if (!tab.url?.startsWith('http') || !tab.id) {
+    return
+  }
 
-	const prevState = await chrome.action.getBadgeText({ tabId: tab.id })
-	const nextState = prevState === 'on' ? '' : 'on'
+  const prevState = await chrome.action.getBadgeText({ tabId: tab.id })
+  const nextState = prevState === 'on' ? '' : 'on'
 
-	await chrome.action.setBadgeText({
-		tabId: tab.id,
-		text: nextState,
-	})
+  await chrome.action.setBadgeText({
+    tabId: tab.id,
+    text: nextState,
+  })
 
-	if (nextState === 'on') {
-		chrome.tabs.sendMessage(tab.id ?? chrome.tabs.TAB_ID_NONE, { status: 'on' })
-	} else {
-		chrome.tabs.sendMessage(tab.id ?? chrome.tabs.TAB_ID_NONE, { status: 'off' })
-	}
+  if (nextState === 'on') {
+    chrome.tabs.sendMessage(tab.id ?? chrome.tabs.TAB_ID_NONE, { status: 'on' })
+  } else {
+    chrome.tabs.sendMessage(tab.id ?? chrome.tabs.TAB_ID_NONE, { status: 'off' })
+  }
 })

--- a/src/background/event.ts
+++ b/src/background/event.ts
@@ -1,30 +1,24 @@
 chrome.runtime.onInstalled.addListener(() => {
-  chrome.action.setBadgeBackgroundColor({ color: "#f4fb04" });
-  chrome.action.setBadgeText({ text: "" });
-});
+	chrome.action.setBadgeBackgroundColor({ color: '#f4fb04' })
+	chrome.action.setBadgeText({ text: '' })
+})
 
 chrome.action.onClicked.addListener(async (tab) => {
-  if (!tab.url?.startsWith('http') || !tab.id) {
-    return
-  }
+	if (!tab.url?.startsWith('http') || !tab.id) {
+		return
+	}
 
-  const prevState = await chrome.action.getBadgeText({ tabId: tab.id });
-  const nextState = prevState === 'on' ? '' : 'on'
+	const prevState = await chrome.action.getBadgeText({ tabId: tab.id })
+	const nextState = prevState === 'on' ? '' : 'on'
 
-  await chrome.action.setBadgeText({
-    tabId: tab.id,
-    text: nextState,
-  });
+	await chrome.action.setBadgeText({
+		tabId: tab.id,
+		text: nextState,
+	})
 
-  if (nextState === "on") {
-    chrome.tabs.sendMessage(
-      tab.id ?? chrome.tabs.TAB_ID_NONE, 
-      { status: "on" }
-    );
-  } else {
-    chrome.tabs.sendMessage(
-      tab.id ?? chrome.tabs.TAB_ID_NONE, 
-      { status: "off" }
-    );
-  }
-});
+	if (nextState === 'on') {
+		chrome.tabs.sendMessage(tab.id ?? chrome.tabs.TAB_ID_NONE, { status: 'on' })
+	} else {
+		chrome.tabs.sendMessage(tab.id ?? chrome.tabs.TAB_ID_NONE, { status: 'off' })
+	}
+})

--- a/src/contentScript/application/index.tsx
+++ b/src/contentScript/application/index.tsx
@@ -1,28 +1,28 @@
-import React from "react";
-import { StrictMode } from "react";
-import { createRoot, Root } from "react-dom/client";
-import { App } from "./src/App";
+import React from 'react'
+import { StrictMode } from 'react'
+import { createRoot, Root } from 'react-dom/client'
+import { App } from './src/App'
 
-let root: Root | null = null;
-const container = document.createElement('div');
-container.id = 'mokcha_root';
-document.body.appendChild(container);
+let root: Root | null = null
+const container = document.createElement('div')
+container.id = 'mokcha_root'
+document.body.appendChild(container)
 
 export const application = {
-  on: () => {
-    if (!root) {
-      root = createRoot(container);
-      root.render(
-        <StrictMode>
-          <App />
-        </StrictMode>
-      );
-    }
-  },
-  off: () => {    
-    if (root) {
-      root.unmount();
-      root = null;
-    }
-  }
-};
+	on: () => {
+		if (!root) {
+			root = createRoot(container)
+			root.render(
+				<StrictMode>
+					<App />
+				</StrictMode>,
+			)
+		}
+	},
+	off: () => {
+		if (root) {
+			root.unmount()
+			root = null
+		}
+	},
+}

--- a/src/contentScript/application/index.tsx
+++ b/src/contentScript/application/index.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { StrictMode } from 'react'
-import { createRoot, type Root } from 'react-dom/client'
+import { type Root, createRoot } from 'react-dom/client'
 import { App } from './src/App'
 
 let root: Root | null = null

--- a/src/contentScript/application/index.tsx
+++ b/src/contentScript/application/index.tsx
@@ -9,20 +9,20 @@ container.id = 'mokcha_root'
 document.body.appendChild(container)
 
 export const application = {
-	on: () => {
-		if (!root) {
-			root = createRoot(container)
-			root.render(
-				<StrictMode>
-					<App />
-				</StrictMode>,
-			)
-		}
-	},
-	off: () => {
-		if (root) {
-			root.unmount()
-			root = null
-		}
-	},
+  on: () => {
+    if (!root) {
+      root = createRoot(container)
+      root.render(
+        <StrictMode>
+          <App />
+        </StrictMode>,
+      )
+    }
+  },
+  off: () => {
+    if (root) {
+      root.unmount()
+      root = null
+    }
+  },
 }

--- a/src/contentScript/application/index.tsx
+++ b/src/contentScript/application/index.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { StrictMode } from 'react'
-import { createRoot, Root } from 'react-dom/client'
+import { createRoot, type Root } from 'react-dom/client'
 import { App } from './src/App'
 
 let root: Root | null = null

--- a/src/contentScript/application/src/App.tsx
+++ b/src/contentScript/application/src/App.tsx
@@ -1,9 +1,7 @@
 import './index.css'
-import React from "react";
+import React from 'react'
 import FloatingToc from './features/FloatingToc'
 
 export function App() {
-  return (
-    <FloatingToc />
-  )
+	return <FloatingToc />
 }

--- a/src/contentScript/application/src/App.tsx
+++ b/src/contentScript/application/src/App.tsx
@@ -2,5 +2,5 @@ import './index.css'
 import FloatingToc from './features/FloatingToc'
 
 export function App() {
-	return <FloatingToc />
+  return <FloatingToc />
 }

--- a/src/contentScript/application/src/App.tsx
+++ b/src/contentScript/application/src/App.tsx
@@ -1,5 +1,4 @@
 import './index.css'
-import React from 'react'
 import FloatingToc from './features/FloatingToc'
 
 export function App() {

--- a/src/contentScript/application/src/components/SwitchCase/SwitchCase.tsx
+++ b/src/contentScript/application/src/components/SwitchCase/SwitchCase.tsx
@@ -1,11 +1,11 @@
 import type { ReactNode } from 'react'
 
 interface SwitchCaseProps<T extends string | number> {
-	value: T
-	cases: {
-		[K in T]: ReactNode
-	}
-	defaultCase?: ReactNode
+  value: T
+  cases: {
+    [K in T]: ReactNode
+  }
+  defaultCase?: ReactNode
 }
 
 /**
@@ -13,11 +13,11 @@ interface SwitchCaseProps<T extends string | number> {
  * @detail value의 case에 해당하는 컴포넌트 렌더링
  */
 export const SwitchCase = <T extends string | number>({
-	value,
-	cases,
-	defaultCase,
+  value,
+  cases,
+  defaultCase,
 }: SwitchCaseProps<T>): ReactNode => {
-	const caseValue = cases[value]
+  const caseValue = cases[value]
 
-	return caseValue !== undefined ? caseValue : defaultCase
+  return caseValue !== undefined ? caseValue : defaultCase
 }

--- a/src/contentScript/application/src/components/SwitchCase/SwitchCase.tsx
+++ b/src/contentScript/application/src/components/SwitchCase/SwitchCase.tsx
@@ -1,11 +1,11 @@
 import { ReactNode } from 'react'
 
 interface SwitchCaseProps<T extends string | number> {
-  value: T
-  cases: {
-    [K in T]: ReactNode
-  }
-  defaultCase?: ReactNode
+	value: T
+	cases: {
+		[K in T]: ReactNode
+	}
+	defaultCase?: ReactNode
 }
 
 /**
@@ -13,11 +13,11 @@ interface SwitchCaseProps<T extends string | number> {
  * @detail value의 case에 해당하는 컴포넌트 렌더링
  */
 export const SwitchCase = <T extends string | number>({
-  value,
-  cases,
-  defaultCase,
+	value,
+	cases,
+	defaultCase,
 }: SwitchCaseProps<T>): ReactNode => {
-  const caseValue = cases[value]
+	const caseValue = cases[value]
 
-  return caseValue !== undefined ? caseValue : defaultCase
+	return caseValue !== undefined ? caseValue : defaultCase
 }

--- a/src/contentScript/application/src/components/SwitchCase/SwitchCase.tsx
+++ b/src/contentScript/application/src/components/SwitchCase/SwitchCase.tsx
@@ -1,4 +1,4 @@
-import { ReactNode } from 'react'
+import type { ReactNode } from 'react'
 
 interface SwitchCaseProps<T extends string | number> {
 	value: T

--- a/src/contentScript/application/src/features/FloatingToc/Container.tsx
+++ b/src/contentScript/application/src/features/FloatingToc/Container.tsx
@@ -3,9 +3,10 @@ import { useReducer } from 'react'
 import { useDragControls } from 'framer-motion'
 import { useEffect, useState } from 'react'
 import { MotionLayout } from './MotionLayout'
-import { Layout } from './Layout'
-import { Header } from './Header'
 import { Toc } from './Toc'
+
+import { Header } from './Header'
+import { Layout } from './Layout'
 
 import { TOC_INITIAL_STATE, tocReducer } from './toc.reducer'
 

--- a/src/contentScript/application/src/features/FloatingToc/Container.tsx
+++ b/src/contentScript/application/src/features/FloatingToc/Container.tsx
@@ -1,57 +1,47 @@
-import React, { useReducer } from "react";
+import React, { useReducer } from 'react'
 
-import { useDragControls } from "framer-motion";
-import { useEffect, useState } from "react";
-import { MotionLayout } from "./MotionLayout";
-import { Layout } from "./Layout";
-import { Header } from "./Header";
-import { Toc } from "./Toc";
-import { TOC_INITIAL_STATE, tocReducer } from "./toc.reducer";
+import { useDragControls } from 'framer-motion'
+import { useEffect, useState } from 'react'
+import { MotionLayout } from './MotionLayout'
+import { Layout } from './Layout'
+import { Header } from './Header'
+import { Toc } from './Toc'
+
+import { TOC_INITIAL_STATE, tocReducer } from './toc.reducer'
 
 const Container = () => {
-  const [constraints, setConstraints] = useState({left: 0, right: 0, top: 0, bottom: 0});
-  const [toc, dispatch] = useReducer(tocReducer, TOC_INITIAL_STATE);
+	const [constraints, setConstraints] = useState({ left: 0, right: 0, top: 0, bottom: 0 })
+	const [toc, dispatch] = useReducer(tocReducer, TOC_INITIAL_STATE)
 
-  const showBigger = toc.type === 'bigger'
+	const showBigger = toc.type === 'bigger'
 
-  const controls= useDragControls()
+	const controls = useDragControls()
 
-  useEffect(() => {
-    setConstraints(prev => ({
-      ...prev,
-      bottom: window.innerHeight - toc.size.height,
-      right: document.documentElement.scrollWidth - toc.size.width
+	useEffect(() => {
+		setConstraints((prev) => ({
+			...prev,
+			bottom: window.innerHeight - toc.size.height,
+			right: document.documentElement.scrollWidth - toc.size.width,
+		}))
+	}, [toc])
 
-    }))
-  }, [toc])
+	const handlePointerDown = (e: React.PointerEvent<HTMLDivElement>) => {
+		controls.start(e)
+	}
 
-  const handlePointerDown = (e: React.PointerEvent<HTMLDivElement>) => {
-    controls.start(e)
-  }
+	const handleTap = () => {
+		dispatch({ type: showBigger ? 'smaller' : 'bigger' })
+	}
 
-  const handleTap = () => {
-    dispatch({type: showBigger ? 'smaller' : 'bigger'})
-  }
+	return (
+		<Layout>
+			<MotionLayout constraints={constraints} controls={controls} tocSize={toc.size}>
+				<Header onPointerDown={handlePointerDown} showBigger={showBigger} />
 
-  return (
-    <Layout>
-      <MotionLayout 
-        constraints={constraints}
-        controls={controls}
-        tocSize={toc.size}
-      >
-        <Header 
-          onPointerDown={handlePointerDown} 
-          showBigger={showBigger}
-        />
-
-        <Toc 
-          onTap={handleTap} 
-          showBigger={showBigger}
-        />
-      </MotionLayout>
-    </Layout>
-  );
+				<Toc onTap={handleTap} showBigger={showBigger} />
+			</MotionLayout>
+		</Layout>
+	)
 }
 
 export default Container

--- a/src/contentScript/application/src/features/FloatingToc/Container.tsx
+++ b/src/contentScript/application/src/features/FloatingToc/Container.tsx
@@ -11,38 +11,38 @@ import { Layout } from './Layout'
 import { TOC_INITIAL_STATE, tocReducer } from './toc.reducer'
 
 const Container = () => {
-	const [constraints, setConstraints] = useState({ left: 0, right: 0, top: 0, bottom: 0 })
-	const [toc, dispatch] = useReducer(tocReducer, TOC_INITIAL_STATE)
+  const [constraints, setConstraints] = useState({ left: 0, right: 0, top: 0, bottom: 0 })
+  const [toc, dispatch] = useReducer(tocReducer, TOC_INITIAL_STATE)
 
-	const showBigger = toc.type === 'bigger'
+  const showBigger = toc.type === 'bigger'
 
-	const controls = useDragControls()
+  const controls = useDragControls()
 
-	useEffect(() => {
-		setConstraints((prev) => ({
-			...prev,
-			bottom: window.innerHeight - toc.size.height,
-			right: document.documentElement.scrollWidth - toc.size.width,
-		}))
-	}, [toc])
+  useEffect(() => {
+    setConstraints((prev) => ({
+      ...prev,
+      bottom: window.innerHeight - toc.size.height,
+      right: document.documentElement.scrollWidth - toc.size.width,
+    }))
+  }, [toc])
 
-	const handlePointerDown = (e: React.PointerEvent<HTMLDivElement>) => {
-		controls.start(e)
-	}
+  const handlePointerDown = (e: React.PointerEvent<HTMLDivElement>) => {
+    controls.start(e)
+  }
 
-	const handleTap = () => {
-		dispatch({ type: showBigger ? 'smaller' : 'bigger' })
-	}
+  const handleTap = () => {
+    dispatch({ type: showBigger ? 'smaller' : 'bigger' })
+  }
 
-	return (
-		<Layout>
-			<MotionLayout constraints={constraints} controls={controls} tocSize={toc.size}>
-				<Header onPointerDown={handlePointerDown} showBigger={showBigger} />
+  return (
+    <Layout>
+      <MotionLayout constraints={constraints} controls={controls} tocSize={toc.size}>
+        <Header onPointerDown={handlePointerDown} showBigger={showBigger} />
 
-				<Toc onTap={handleTap} showBigger={showBigger} />
-			</MotionLayout>
-		</Layout>
-	)
+        <Toc onTap={handleTap} showBigger={showBigger} />
+      </MotionLayout>
+    </Layout>
+  )
 }
 
 export default Container

--- a/src/contentScript/application/src/features/FloatingToc/Container.tsx
+++ b/src/contentScript/application/src/features/FloatingToc/Container.tsx
@@ -1,4 +1,4 @@
-import React, { useReducer } from 'react'
+import { useReducer } from 'react'
 
 import { useDragControls } from 'framer-motion'
 import { useEffect, useState } from 'react'

--- a/src/contentScript/application/src/features/FloatingToc/Header.tsx
+++ b/src/contentScript/application/src/features/FloatingToc/Header.tsx
@@ -1,5 +1,5 @@
+import { useState } from 'react'
 import { motion } from 'framer-motion'
-import React, { useState } from 'react'
 
 interface Props {
 	onPointerDown: (e: React.PointerEvent<HTMLDivElement>) => void

--- a/src/contentScript/application/src/features/FloatingToc/Header.tsx
+++ b/src/contentScript/application/src/features/FloatingToc/Header.tsx
@@ -2,58 +2,58 @@ import { motion } from 'framer-motion'
 import { useState } from 'react'
 
 interface Props {
-	onPointerDown: (e: React.PointerEvent<HTMLDivElement>) => void
-	showBigger: boolean
+  onPointerDown: (e: React.PointerEvent<HTMLDivElement>) => void
+  showBigger: boolean
 }
 export const Header = (props: Props) => {
-	const [isGrabbing, setIsGrabbing] = useState(false)
+  const [isGrabbing, setIsGrabbing] = useState(false)
 
-	const handlePointerDown = (e: React.PointerEvent<HTMLDivElement>) => {
-		setIsGrabbing(true)
-		props.onPointerDown(e)
-	}
+  const handlePointerDown = (e: React.PointerEvent<HTMLDivElement>) => {
+    setIsGrabbing(true)
+    props.onPointerDown(e)
+  }
 
-	const handlePointerUp = () => {
-		setIsGrabbing(false)
-	}
+  const handlePointerUp = () => {
+    setIsGrabbing(false)
+  }
 
-	return (
-		<motion.div
-			layout
-			onPointerDown={handlePointerDown}
-			onPointerUp={handlePointerUp}
-			className="!bg-white flex justify-center flex-col"
-			style={{
-				display: 'flex',
-				alignItems: 'center',
-				flexDirection: 'column',
-				cursor: isGrabbing ? 'grabbing' : 'grab',
-				height: '55px',
-			}}
-		>
-			<h1
-				id="toc-title"
-				style={{
-					padding: '15px 10px',
-					position: 'relative',
-					fontSize: props.showBigger ? '16px' : '13px',
-				}}
-			>
-				<span
-					style={{ position: 'absolute', left: -15, display: props.showBigger ? 'block' : 'none' }}
-				>
-					☁️
-				</span>
-				<span style={{ fontWeight: 'bold' }}>Floating Table of Contents</span>
-			</h1>
+  return (
+    <motion.div
+      layout
+      onPointerDown={handlePointerDown}
+      onPointerUp={handlePointerUp}
+      className="!bg-white flex justify-center flex-col"
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        flexDirection: 'column',
+        cursor: isGrabbing ? 'grabbing' : 'grab',
+        height: '55px',
+      }}
+    >
+      <h1
+        id="toc-title"
+        style={{
+          padding: '15px 10px',
+          position: 'relative',
+          fontSize: props.showBigger ? '16px' : '13px',
+        }}
+      >
+        <span
+          style={{ position: 'absolute', left: -15, display: props.showBigger ? 'block' : 'none' }}
+        >
+          ☁️
+        </span>
+        <span style={{ fontWeight: 'bold' }}>Floating Table of Contents</span>
+      </h1>
 
-			<div
-				style={{
-					height: '0.5px',
-					width: 'calc(100% - 20px)',
-					backgroundColor: '#D5D5D5',
-				}}
-			/>
-		</motion.div>
-	)
+      <div
+        style={{
+          height: '0.5px',
+          width: 'calc(100% - 20px)',
+          backgroundColor: '#D5D5D5',
+        }}
+      />
+    </motion.div>
+  )
 }

--- a/src/contentScript/application/src/features/FloatingToc/Header.tsx
+++ b/src/contentScript/application/src/features/FloatingToc/Header.tsx
@@ -1,55 +1,59 @@
-import { motion } from "framer-motion";
-import React, { useState } from "react";
+import { motion } from 'framer-motion'
+import React, { useState } from 'react'
 
 interface Props {
-  onPointerDown: (e: React.PointerEvent<HTMLDivElement>) => void
-  showBigger: boolean
+	onPointerDown: (e: React.PointerEvent<HTMLDivElement>) => void
+	showBigger: boolean
 }
 export const Header = (props: Props) => {
-  const [isGrabbing, setIsGrabbing] = useState(false);
+	const [isGrabbing, setIsGrabbing] = useState(false)
 
-  const handlePointerDown = (e: React.PointerEvent<HTMLDivElement>) => {
-    setIsGrabbing(true);
-    props.onPointerDown(e);
-  };
+	const handlePointerDown = (e: React.PointerEvent<HTMLDivElement>) => {
+		setIsGrabbing(true)
+		props.onPointerDown(e)
+	}
 
-  const handlePointerUp = () => {
-    setIsGrabbing(false);
-  };
+	const handlePointerUp = () => {
+		setIsGrabbing(false)
+	}
 
-  return (
-    <motion.div 
-      layout
-      onPointerDown={handlePointerDown}
-      onPointerUp={handlePointerUp}
-      className="!bg-white flex justify-center flex-col"
-      style={{
-        display: 'flex',
-        alignItems: 'center',
-        flexDirection: 'column',
-        cursor: isGrabbing ? 'grabbing' : 'grab',
-        height: '55px',
-      }}
-    >
-      <h1
-        id="toc-title"
-        style={{
-          padding: '15px 10px',
-          position: 'relative',
-          fontSize: props.showBigger ? '16px': '13px',
-        }}
-      >
-        <span style={{position: 'absolute', left: -15, display: props.showBigger ? 'block' : 'none'}}>☁️</span> 
-        <span style={{fontWeight: 'bold' }}>Floating Table of Contents</span>
-      </h1>
+	return (
+		<motion.div
+			layout
+			onPointerDown={handlePointerDown}
+			onPointerUp={handlePointerUp}
+			className="!bg-white flex justify-center flex-col"
+			style={{
+				display: 'flex',
+				alignItems: 'center',
+				flexDirection: 'column',
+				cursor: isGrabbing ? 'grabbing' : 'grab',
+				height: '55px',
+			}}
+		>
+			<h1
+				id="toc-title"
+				style={{
+					padding: '15px 10px',
+					position: 'relative',
+					fontSize: props.showBigger ? '16px' : '13px',
+				}}
+			>
+				<span
+					style={{ position: 'absolute', left: -15, display: props.showBigger ? 'block' : 'none' }}
+				>
+					☁️
+				</span>
+				<span style={{ fontWeight: 'bold' }}>Floating Table of Contents</span>
+			</h1>
 
-      <div 
-        style={{
-          height:'0.5px',
-          width: 'calc(100% - 20px)',
-          backgroundColor: '#D5D5D5',
-        }}
-      />
-  </motion.div>
-  )
+			<div
+				style={{
+					height: '0.5px',
+					width: 'calc(100% - 20px)',
+					backgroundColor: '#D5D5D5',
+				}}
+			/>
+		</motion.div>
+	)
 }

--- a/src/contentScript/application/src/features/FloatingToc/Header.tsx
+++ b/src/contentScript/application/src/features/FloatingToc/Header.tsx
@@ -1,5 +1,5 @@
-import { useState } from 'react'
 import { motion } from 'framer-motion'
+import { useState } from 'react'
 
 interface Props {
 	onPointerDown: (e: React.PointerEvent<HTMLDivElement>) => void

--- a/src/contentScript/application/src/features/FloatingToc/Layout.tsx
+++ b/src/contentScript/application/src/features/FloatingToc/Layout.tsx
@@ -1,19 +1,19 @@
 export const Layout = (props: {
-	children: React.ReactNode
+  children: React.ReactNode
 }) => {
-	return (
-		<div
-			style={{
-				position: 'absolute',
-				top: 0,
-				left: 0,
-				width: '100%',
-				overflow: 'hidden',
-				pointerEvents: 'none',
-				zIndex: 1000,
-			}}
-		>
-			{props.children}
-		</div>
-	)
+  return (
+    <div
+      style={{
+        position: 'absolute',
+        top: 0,
+        left: 0,
+        width: '100%',
+        overflow: 'hidden',
+        pointerEvents: 'none',
+        zIndex: 1000,
+      }}
+    >
+      {props.children}
+    </div>
+  )
 }

--- a/src/contentScript/application/src/features/FloatingToc/Layout.tsx
+++ b/src/contentScript/application/src/features/FloatingToc/Layout.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 export const Layout = (props: {
 	children: React.ReactNode
 }) => {

--- a/src/contentScript/application/src/features/FloatingToc/Layout.tsx
+++ b/src/contentScript/application/src/features/FloatingToc/Layout.tsx
@@ -1,21 +1,21 @@
-import React from "react";
+import React from 'react'
 
 export const Layout = (props: {
-  children: React.ReactNode
+	children: React.ReactNode
 }) => {
-  return (
-    <div 
-      style={{
-        position: 'absolute',
-        top: 0,
-        left: 0,
-        width: '100%',
-        overflow: 'hidden',
-        pointerEvents: 'none',
-        zIndex: 1000
-      }}
-      >
-    {props.children}
-  </div>
-  )
+	return (
+		<div
+			style={{
+				position: 'absolute',
+				top: 0,
+				left: 0,
+				width: '100%',
+				overflow: 'hidden',
+				pointerEvents: 'none',
+				zIndex: 1000,
+			}}
+		>
+			{props.children}
+		</div>
+	)
 }

--- a/src/contentScript/application/src/features/FloatingToc/MotionLayout.tsx
+++ b/src/contentScript/application/src/features/FloatingToc/MotionLayout.tsx
@@ -1,49 +1,46 @@
-import { DragControls, motion, PanInfo } from "framer-motion";
-import React, { useState } from "react";
+import { DragControls, motion, PanInfo } from 'framer-motion'
+import React, { useState } from 'react'
 
 interface Props {
-  children: React.ReactNode
-  controls: DragControls
-  constraints: {
-    left: number
-    right: number
-    top: number
-    bottom: number
-  }
-  tocSize: {
-    width: number
-    height: number
-  }
+	children: React.ReactNode
+	controls: DragControls
+	constraints: {
+		left: number
+		right: number
+		top: number
+		bottom: number
+	}
+	tocSize: {
+		width: number
+		height: number
+	}
 }
 
 export const MotionLayout = (props: Props) => {
-
-  return (
-    <motion.div 
-      drag 
-      dragConstraints={props.constraints}
-      dragControls={props.controls}
-      dragListener={false}
-      
-      animate={{x:200, y: 200}}
-      layout
-      whileHover={{
-        scale: 1.05,
-      }}
-
-      style={{
-        position: 'fixed',
-        pointerEvents: 'auto',
-        width: props.tocSize.width, 
-        height: props.tocSize.height,
-        borderRadius: '10px',
-        boxShadow: 'rgba(60, 64, 67, 0.3) 0px 1px 2px 0px, rgba(60, 64, 67, 0.15) 0px 2px 6px 2px',
-        overflow: 'hidden',
-        zIndex: 1,
-        backgroundColor: 'white'
-      }}
-    >
-      {props.children}
-    </motion.div>
-  )
+	return (
+		<motion.div
+			drag
+			dragConstraints={props.constraints}
+			dragControls={props.controls}
+			dragListener={false}
+			animate={{ x: 200, y: 200 }}
+			layout
+			whileHover={{
+				scale: 1.05,
+			}}
+			style={{
+				position: 'fixed',
+				pointerEvents: 'auto',
+				width: props.tocSize.width,
+				height: props.tocSize.height,
+				borderRadius: '10px',
+				boxShadow: 'rgba(60, 64, 67, 0.3) 0px 1px 2px 0px, rgba(60, 64, 67, 0.15) 0px 2px 6px 2px',
+				overflow: 'hidden',
+				zIndex: 1,
+				backgroundColor: 'white',
+			}}
+		>
+			{props.children}
+		</motion.div>
+	)
 }

--- a/src/contentScript/application/src/features/FloatingToc/MotionLayout.tsx
+++ b/src/contentScript/application/src/features/FloatingToc/MotionLayout.tsx
@@ -1,45 +1,45 @@
 import { type DragControls, motion } from 'framer-motion'
 
 interface Props {
-	children: React.ReactNode
-	controls: DragControls
-	constraints: {
-		left: number
-		right: number
-		top: number
-		bottom: number
-	}
-	tocSize: {
-		width: number
-		height: number
-	}
+  children: React.ReactNode
+  controls: DragControls
+  constraints: {
+    left: number
+    right: number
+    top: number
+    bottom: number
+  }
+  tocSize: {
+    width: number
+    height: number
+  }
 }
 
 export const MotionLayout = (props: Props) => {
-	return (
-		<motion.div
-			drag
-			dragConstraints={props.constraints}
-			dragControls={props.controls}
-			dragListener={false}
-			animate={{ x: 200, y: 200 }}
-			layout
-			whileHover={{
-				scale: 1.05,
-			}}
-			style={{
-				position: 'fixed',
-				pointerEvents: 'auto',
-				width: props.tocSize.width,
-				height: props.tocSize.height,
-				borderRadius: '10px',
-				boxShadow: 'rgba(60, 64, 67, 0.3) 0px 1px 2px 0px, rgba(60, 64, 67, 0.15) 0px 2px 6px 2px',
-				overflow: 'hidden',
-				zIndex: 1,
-				backgroundColor: 'white',
-			}}
-		>
-			{props.children}
-		</motion.div>
-	)
+  return (
+    <motion.div
+      drag
+      dragConstraints={props.constraints}
+      dragControls={props.controls}
+      dragListener={false}
+      animate={{ x: 200, y: 200 }}
+      layout
+      whileHover={{
+        scale: 1.05,
+      }}
+      style={{
+        position: 'fixed',
+        pointerEvents: 'auto',
+        width: props.tocSize.width,
+        height: props.tocSize.height,
+        borderRadius: '10px',
+        boxShadow: 'rgba(60, 64, 67, 0.3) 0px 1px 2px 0px, rgba(60, 64, 67, 0.15) 0px 2px 6px 2px',
+        overflow: 'hidden',
+        zIndex: 1,
+        backgroundColor: 'white',
+      }}
+    >
+      {props.children}
+    </motion.div>
+  )
 }

--- a/src/contentScript/application/src/features/FloatingToc/MotionLayout.tsx
+++ b/src/contentScript/application/src/features/FloatingToc/MotionLayout.tsx
@@ -1,5 +1,4 @@
-import { DragControls, motion, PanInfo } from 'framer-motion'
-import React, { useState } from 'react'
+import { type DragControls, motion } from 'framer-motion'
 
 interface Props {
 	children: React.ReactNode

--- a/src/contentScript/application/src/features/FloatingToc/Toc.tsx
+++ b/src/contentScript/application/src/features/FloatingToc/Toc.tsx
@@ -1,100 +1,111 @@
-import { motion } from "framer-motion";
-import React, { useEffect, useState } from "react";
-import { SwitchCase } from "../../components/SwitchCase";
+import { motion } from 'framer-motion'
+import React, { useEffect, useState } from 'react'
+import { SwitchCase } from '../../components/SwitchCase'
 
 interface Props {
-  onTap: () => void
-  showBigger: boolean
+	onTap: () => void
+	showBigger: boolean
 }
 
 type HeadingInfo = {
-  text: string
-  id: string
-  level: number
+	text: string
+	id: string
+	level: number
 }
 
 export const Toc = (props: Props) => {
-  const [headingInfo, setHeadingInfo] = useState<HeadingInfo[] | null>(null);
+	const [headingInfo, setHeadingInfo] = useState<HeadingInfo[] | null>(null)
 
-  const hasHeadingInfo = headingInfo && headingInfo.length > 0;
+	const hasHeadingInfo = headingInfo && headingInfo.length > 0
 
-  useEffect(() => {
-    setHeadingInfo(getHeadingInfo())
-  }, [])
+	useEffect(() => {
+		setHeadingInfo(getHeadingInfo())
+	}, [])
 
-  return (
-    <motion.div
-      layout
-      onClick={props.onTap}
-      style={{height: 'calc(100% - 55px)', width: '100%', padding: '20px 0 10px', outline: 'none', overflow: 'auto'}}
-    >
-      <SwitchCase 
-        value={hasHeadingInfo ? 'fill' : 'empty'} 
-        cases={{
-          fill: (
-            <ul style={{
-              fontSize: props.showBigger ? '16px': '13px',
-              display: 'flex',
-              flexDirection: 'column',
-              gap: '5px',
-              }}>
-            {headingInfo?.map((headingInfo) => {
-              return (
-                <motion.li 
-                  key={headingInfo.id} 
-                  style={{
-                    paddingLeft: headingInfo.level * 10,
-                    paddingRight: 10,
-                  }} 
-                 
-                >
-                  <a 
-                    href={`#${headingInfo.id}`}
-                    onClick={e => e.stopPropagation()}
-                  >
-                    {headingInfo.text}
-                  </a>
-                </motion.li>
-              )
-            })}
-          </ul>
-          ),
-          empty: (
-            <div style={{display: 'flex', justifyContent: 'center', alignItems: 'center', height: 'calc(100% - 40px)'}}>
-              empty..
-            </div>
-          )
-        }}
-      />
-  </motion.div>
-  )
+	return (
+		<motion.div
+			layout
+			onClick={props.onTap}
+			style={{
+				height: 'calc(100% - 55px)',
+				width: '100%',
+				padding: '20px 0 10px',
+				outline: 'none',
+				overflow: 'auto',
+			}}
+		>
+			<SwitchCase
+				value={hasHeadingInfo ? 'fill' : 'empty'}
+				cases={{
+					fill: (
+						<ul
+							style={{
+								fontSize: props.showBigger ? '16px' : '13px',
+								display: 'flex',
+								flexDirection: 'column',
+								gap: '5px',
+							}}
+						>
+							{headingInfo?.map((headingInfo) => {
+								return (
+									<motion.li
+										key={headingInfo.id}
+										style={{
+											paddingLeft: headingInfo.level * 10,
+											paddingRight: 10,
+										}}
+									>
+										<a href={`#${headingInfo.id}`} onClick={(e) => e.stopPropagation()}>
+											{headingInfo.text}
+										</a>
+									</motion.li>
+								)
+							})}
+						</ul>
+					),
+					empty: (
+						<div
+							style={{
+								display: 'flex',
+								justifyContent: 'center',
+								alignItems: 'center',
+								height: 'calc(100% - 40px)',
+							}}
+						>
+							empty..
+						</div>
+					),
+				}}
+			/>
+		</motion.div>
+	)
 }
 
 function getHeadingInfo(): HeadingInfo[] {
-  const main = document.querySelector('main')
+	const main = document.querySelector('main')
 
-  const headings = main 
-    ? main.querySelectorAll('h1, h2, h3, h4') 
-    : document.querySelectorAll('h1, h2, h3, h4');
+	const headings = main
+		? main.querySelectorAll('h1, h2, h3, h4')
+		: document.querySelectorAll('h1, h2, h3, h4')
 
-  headings.forEach((heading, index) => {
-    if (heading.id !== 'toc-title') {
-      heading.id = `toc-heading-${index}`
-    }
-  })
-  
-  const info: HeadingInfo[] = [...headings]
-    .filter(heading => heading.id !== 'toc-title')
-    .map((heading, index) => {
-      const [_, level] = [...heading.tagName]
+	headings.forEach((heading, index) => {
+		if (heading.id !== 'toc-title') {
+			heading.id = `toc-heading-${index}`
+		}
+	})
 
-      return ({
-        text: heading.textContent ?? '',
-        id: `toc-heading-${index}`,
-        level: Number(level)
-      })
-    })
-    .filter(headingInfo => headingInfo.text !== '')
+	const info: HeadingInfo[] = [...headings]
+		.filter((heading) => heading.id !== 'toc-title')
+		.map((heading, index) => {
+			const [_, level] = [...heading.tagName]
 
-    return info
+			return {
+				text: heading.textContent ?? '',
+				id: `toc-heading-${index}`,
+				level: Number(level),
+			}
+		})
+		.filter((headingInfo) => headingInfo.text !== '')
+
+	return info
 }

--- a/src/contentScript/application/src/features/FloatingToc/Toc.tsx
+++ b/src/contentScript/application/src/features/FloatingToc/Toc.tsx
@@ -1,5 +1,5 @@
 import { motion } from 'framer-motion'
-import React, { useEffect, useState } from 'react'
+import { useEffect, useState } from 'react'
 import { SwitchCase } from '../../components/SwitchCase'
 
 interface Props {

--- a/src/contentScript/application/src/features/FloatingToc/Toc.tsx
+++ b/src/contentScript/application/src/features/FloatingToc/Toc.tsx
@@ -3,109 +3,109 @@ import { useEffect, useState } from 'react'
 import { SwitchCase } from '../../components/SwitchCase'
 
 interface Props {
-	onTap: () => void
-	showBigger: boolean
+  onTap: () => void
+  showBigger: boolean
 }
 
 type HeadingInfo = {
-	text: string
-	id: string
-	level: number
+  text: string
+  id: string
+  level: number
 }
 
 export const Toc = (props: Props) => {
-	const [headingInfo, setHeadingInfo] = useState<HeadingInfo[] | null>(null)
+  const [headingInfo, setHeadingInfo] = useState<HeadingInfo[] | null>(null)
 
-	const hasHeadingInfo = headingInfo && headingInfo.length > 0
+  const hasHeadingInfo = headingInfo && headingInfo.length > 0
 
-	useEffect(() => {
-		setHeadingInfo(getHeadingInfo())
-	}, [])
+  useEffect(() => {
+    setHeadingInfo(getHeadingInfo())
+  }, [])
 
-	return (
-		<motion.div
-			layout
-			onClick={props.onTap}
-			style={{
-				height: 'calc(100% - 55px)',
-				width: '100%',
-				padding: '20px 0 10px',
-				outline: 'none',
-				overflow: 'auto',
-			}}
-		>
-			<SwitchCase
-				value={hasHeadingInfo ? 'fill' : 'empty'}
-				cases={{
-					fill: (
-						<ul
-							style={{
-								fontSize: props.showBigger ? '16px' : '13px',
-								display: 'flex',
-								flexDirection: 'column',
-								gap: '5px',
-							}}
-						>
-							{headingInfo?.map((headingInfo) => {
-								return (
-									<motion.li
-										key={headingInfo.id}
-										style={{
-											paddingLeft: headingInfo.level * 10,
-											paddingRight: 10,
-										}}
-									>
-										<a href={`#${headingInfo.id}`} onClick={(e) => e.stopPropagation()}>
-											{headingInfo.text}
-										</a>
-									</motion.li>
-								)
-							})}
-						</ul>
-					),
-					empty: (
-						<div
-							style={{
-								display: 'flex',
-								justifyContent: 'center',
-								alignItems: 'center',
-								height: 'calc(100% - 40px)',
-							}}
-						>
-							empty..
-						</div>
-					),
-				}}
-			/>
-		</motion.div>
-	)
+  return (
+    <motion.div
+      layout
+      onClick={props.onTap}
+      style={{
+        height: 'calc(100% - 55px)',
+        width: '100%',
+        padding: '20px 0 10px',
+        outline: 'none',
+        overflow: 'auto',
+      }}
+    >
+      <SwitchCase
+        value={hasHeadingInfo ? 'fill' : 'empty'}
+        cases={{
+          fill: (
+            <ul
+              style={{
+                fontSize: props.showBigger ? '16px' : '13px',
+                display: 'flex',
+                flexDirection: 'column',
+                gap: '5px',
+              }}
+            >
+              {headingInfo?.map((headingInfo) => {
+                return (
+                  <motion.li
+                    key={headingInfo.id}
+                    style={{
+                      paddingLeft: headingInfo.level * 10,
+                      paddingRight: 10,
+                    }}
+                  >
+                    <a href={`#${headingInfo.id}`} onClick={(e) => e.stopPropagation()}>
+                      {headingInfo.text}
+                    </a>
+                  </motion.li>
+                )
+              })}
+            </ul>
+          ),
+          empty: (
+            <div
+              style={{
+                display: 'flex',
+                justifyContent: 'center',
+                alignItems: 'center',
+                height: 'calc(100% - 40px)',
+              }}
+            >
+              empty..
+            </div>
+          ),
+        }}
+      />
+    </motion.div>
+  )
 }
 
 function getHeadingInfo(): HeadingInfo[] {
-	const main = document.querySelector('main')
+  const main = document.querySelector('main')
 
-	const headings = main
-		? main.querySelectorAll('h1, h2, h3, h4')
-		: document.querySelectorAll('h1, h2, h3, h4')
+  const headings = main
+    ? main.querySelectorAll('h1, h2, h3, h4')
+    : document.querySelectorAll('h1, h2, h3, h4')
 
-	headings.forEach((heading, index) => {
-		if (heading.id !== 'toc-title') {
-			heading.id = `toc-heading-${index}`
-		}
-	})
+  headings.forEach((heading, index) => {
+    if (heading.id !== 'toc-title') {
+      heading.id = `toc-heading-${index}`
+    }
+  })
 
-	const info: HeadingInfo[] = [...headings]
-		.filter((heading) => heading.id !== 'toc-title')
-		.map((heading, index) => {
-			const [_, level] = [...heading.tagName]
+  const info: HeadingInfo[] = [...headings]
+    .filter((heading) => heading.id !== 'toc-title')
+    .map((heading, index) => {
+      const [_, level] = [...heading.tagName]
 
-			return {
-				text: heading.textContent ?? '',
-				id: `toc-heading-${index}`,
-				level: Number(level),
-			}
-		})
-		.filter((headingInfo) => headingInfo.text !== '')
+      return {
+        text: heading.textContent ?? '',
+        id: `toc-heading-${index}`,
+        level: Number(level),
+      }
+    })
+    .filter((headingInfo) => headingInfo.text !== '')
 
-	return info
+  return info
 }

--- a/src/contentScript/application/src/features/FloatingToc/toc.reducer.ts
+++ b/src/contentScript/application/src/features/FloatingToc/toc.reducer.ts
@@ -1,46 +1,46 @@
 type TocType = 'bigger' | 'smaller'
 
 type Toc = {
-	type: TocType
-	size: TocSize
+  type: TocType
+  size: TocSize
 }
 
 type TocSize = {
-	width: number
-	height: number
+  width: number
+  height: number
 }
 
 type TocAction = {
-	type: TocType
+  type: TocType
 }
 
 const TOC_SIZE = {
-	bigger: {
-		width: 300,
-		height: 300,
-	},
-	smaller: {
-		width: 250,
-		height: 200,
-	},
+  bigger: {
+    width: 300,
+    height: 300,
+  },
+  smaller: {
+    width: 250,
+    height: 200,
+  },
 }
 
 export const TOC_INITIAL_STATE: Toc = {
-	type: 'bigger',
-	size: TOC_SIZE.bigger,
+  type: 'bigger',
+  size: TOC_SIZE.bigger,
 }
 
 export const tocReducer = (state: Toc, action: TocAction) => {
-	switch (action.type) {
-		case 'bigger':
-			return {
-				type: 'bigger' as const,
-				size: TOC_SIZE.bigger,
-			}
-		case 'smaller':
-			return {
-				type: 'smaller' as const,
-				size: TOC_SIZE.smaller,
-			}
-	}
+  switch (action.type) {
+    case 'bigger':
+      return {
+        type: 'bigger' as const,
+        size: TOC_SIZE.bigger,
+      }
+    case 'smaller':
+      return {
+        type: 'smaller' as const,
+        size: TOC_SIZE.smaller,
+      }
+  }
 }

--- a/src/contentScript/application/src/features/FloatingToc/toc.reducer.ts
+++ b/src/contentScript/application/src/features/FloatingToc/toc.reducer.ts
@@ -1,45 +1,46 @@
-type TocType = "bigger" | "smaller"
+type TocType = 'bigger' | 'smaller'
 
 type Toc = {
-  type: TocType
-  size: TocSize
+	type: TocType
+	size: TocSize
 }
 
 type TocSize = {
-  width: number
-  height: number
+	width: number
+	height: number
 }
 
 type TocAction = {
-  type: TocType
+	type: TocType
 }
 
 const TOC_SIZE = {
-  bigger: {
-    width: 300,
-    height: 300
-  },
-  smaller: {
-    width: 250,
-    height: 200
-  }
+	bigger: {
+		width: 300,
+		height: 300,
+	},
+	smaller: {
+		width: 250,
+		height: 200,
+	},
 }
 
 export const TOC_INITIAL_STATE: Toc = {
-  type: 'bigger',
-  size: TOC_SIZE.bigger
+	type: 'bigger',
+	size: TOC_SIZE.bigger,
 }
 
 export const tocReducer = (state: Toc, action: TocAction) => {
-  switch (action.type) {
-    case 'bigger':
-      return {
-        type: 'bigger' as const,
-        size: TOC_SIZE.bigger}
-    case 'smaller':
-      return {
-        type: 'smaller' as const,
-        size: TOC_SIZE.smaller
-      }
-  }
+	switch (action.type) {
+		case 'bigger':
+			return {
+				type: 'bigger' as const,
+				size: TOC_SIZE.bigger,
+			}
+		case 'smaller':
+			return {
+				type: 'smaller' as const,
+				size: TOC_SIZE.smaller,
+			}
+	}
 }

--- a/src/contentScript/application/src/index.css
+++ b/src/contentScript/application/src/index.css
@@ -1,5 +1,5 @@
 #mokcha_root {
-  @tailwind base;
-  @tailwind components;
-  @tailwind utilities;
+	@tailwind base;
+	@tailwind components;
+	@tailwind utilities;
 }

--- a/src/contentScript/application/src/index.css
+++ b/src/contentScript/application/src/index.css
@@ -1,5 +1,5 @@
 #mokcha_root {
-	@tailwind base;
-	@tailwind components;
-	@tailwind utilities;
+  @tailwind base;
+  @tailwind components;
+  @tailwind utilities;
 }

--- a/src/contentScript/application/tsconfig.json
+++ b/src/contentScript/application/tsconfig.json
@@ -1,6 +1,6 @@
 {
 	"compilerOptions": {
-		"jsx": "react",
+		"jsx": "react-jsx",
 		"module": "esnext",
 		"strict": true,
 		"moduleResolution": "bundler",

--- a/src/contentScript/application/tsconfig.json
+++ b/src/contentScript/application/tsconfig.json
@@ -1,15 +1,15 @@
 {
-  "compilerOptions": {
-    "jsx": "react",
-    "module": "esnext",
-    "strict": true,
-    "moduleResolution": "bundler",
-    "target": "ES6"
-  },
-  "include": ["./src"],
-  "references": [
-    {
-      "path": "../../../tsconfig.json"
-    }
-  ]
+	"compilerOptions": {
+		"jsx": "react",
+		"module": "esnext",
+		"strict": true,
+		"moduleResolution": "bundler",
+		"target": "ES6"
+	},
+	"include": ["./src"],
+	"references": [
+		{
+			"path": "../../../tsconfig.json"
+		}
+	]
 }

--- a/src/contentScript/application/tsconfig.json
+++ b/src/contentScript/application/tsconfig.json
@@ -1,15 +1,15 @@
 {
-	"compilerOptions": {
-		"jsx": "react-jsx",
-		"module": "esnext",
-		"strict": true,
-		"moduleResolution": "bundler",
-		"target": "ES6"
-	},
-	"include": ["./src"],
-	"references": [
-		{
-			"path": "../../../tsconfig.json"
-		}
-	]
+  "compilerOptions": {
+    "jsx": "react-jsx",
+    "module": "esnext",
+    "strict": true,
+    "moduleResolution": "bundler",
+    "target": "ES6"
+  },
+  "include": ["./src"],
+  "references": [
+    {
+      "path": "../../../tsconfig.json"
+    }
+  ]
 }

--- a/src/contentScript/event.ts
+++ b/src/contentScript/event.ts
@@ -1,13 +1,13 @@
-import { application } from "./application/index";
+import { application } from './application/index'
 
 chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
-  if (message.status === "on") {
-    application.on();
-  }
-});
+	if (message.status === 'on') {
+		application.on()
+	}
+})
 
 chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
-  if (message.status === "off") {
-    application.off();
-  }
-});
+	if (message.status === 'off') {
+		application.off()
+	}
+})

--- a/src/contentScript/event.ts
+++ b/src/contentScript/event.ts
@@ -1,13 +1,13 @@
 import { application } from './application/index'
 
 chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
-	if (message.status === 'on') {
-		application.on()
-	}
+  if (message.status === 'on') {
+    application.on()
+  }
 })
 
 chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
-	if (message.status === 'off') {
-		application.off()
-	}
+  if (message.status === 'off') {
+    application.off()
+  }
 })

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,8 +1,8 @@
 /** @type {import('tailwindcss').Config} */
 export default {
-	content: ['./src/contentScript/application/src/*.{js,ts,jsx,tsx}'],
-	theme: {
-		extend: {},
-	},
-	plugins: [],
+  content: ['./src/contentScript/application/src/*.{js,ts,jsx,tsx}'],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
 }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,11 +1,8 @@
 /** @type {import('tailwindcss').Config} */
 export default {
-  content: [
-    "./src/contentScript/application/src/*.{js,ts,jsx,tsx}",
-  ],
-  theme: {
-    extend: {},
-  },
-  plugins: [],
+	content: ['./src/contentScript/application/src/*.{js,ts,jsx,tsx}'],
+	theme: {
+		extend: {},
+	},
+	plugins: [],
 }
-

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,34 +1,34 @@
 {
-	"compilerOptions": {
-		/* Visit https://aka.ms/tsconfig to read more about this file */
+  "compilerOptions": {
+    /* Visit https://aka.ms/tsconfig to read more about this file */
 
-		/* Language and Environment */
-		"target": "es2016" /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */,
-		"lib": ["ES2022", "DOM", "DOM.Iterable"],
+    /* Language and Environment */
+    "target": "es2016" /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */,
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
 
-		/* Modules */
-		"module": "ES2022" /* Specify what module code is generated. */,
-		"rootDir": "src",
-		"noImplicitOverride": true,
+    /* Modules */
+    "module": "ES2022" /* Specify what module code is generated. */,
+    "rootDir": "src",
+    "noImplicitOverride": true,
 
-		/* Emit */
-		"sourceMap": true /* Create source map files for emitted JavaScript files. */,
-		// "inlineSourceMap": true,                          /* Include sourcemap files inside the emitted JavaScript. */
-		"noEmit": false /* Disable emitting files from a compilation. */,
-		// "outFile": "./",                                  /* Specify a file that bundles all outputs into one JavaScript file. If 'declaration' is true, also designates a file that bundles all .d.ts output. */
-		"outDir": "dist",
+    /* Emit */
+    "sourceMap": true /* Create source map files for emitted JavaScript files. */,
+    // "inlineSourceMap": true,                          /* Include sourcemap files inside the emitted JavaScript. */
+    "noEmit": false /* Disable emitting files from a compilation. */,
+    // "outFile": "./",                                  /* Specify a file that bundles all outputs into one JavaScript file. If 'declaration' is true, also designates a file that bundles all .d.ts output. */
+    "outDir": "dist",
 
-		"esModuleInterop": true /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables 'allowSyntheticDefaultImports' for type compatibility. */,
-		// "preserveSymlinks": true,                         /* Disable resolving symlinks to their realpath. This correlates to the same flag in node. */
-		"forceConsistentCasingInFileNames": true /* Ensure that casing is correct in imports. */,
+    "esModuleInterop": true /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables 'allowSyntheticDefaultImports' for type compatibility. */,
+    // "preserveSymlinks": true,                         /* Disable resolving symlinks to their realpath. This correlates to the same flag in node. */
+    "forceConsistentCasingInFileNames": true /* Ensure that casing is correct in imports. */,
 
-		/* Type Checking */
-		"strict": true /* Enable all strict type-checking options. */,
-		"noImplicitAny": true /* Enable error reporting for expressions and declarations with an implied 'any' type. */,
-		"skipLibCheck": true /* Skip type checking all .d.ts files. */,
+    /* Type Checking */
+    "strict": true /* Enable all strict type-checking options. */,
+    "noImplicitAny": true /* Enable error reporting for expressions and declarations with an implied 'any' type. */,
+    "skipLibCheck": true /* Skip type checking all .d.ts files. */,
 
-		"composite": true
-	},
-	"include": ["src/**/*"],
-	"exclude": ["src/contentScript"]
+    "composite": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["src/contentScript"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,39 +1,34 @@
 {
-  "compilerOptions": {
-    /* Visit https://aka.ms/tsconfig to read more about this file */
+	"compilerOptions": {
+		/* Visit https://aka.ms/tsconfig to read more about this file */
 
+		/* Language and Environment */
+		"target": "es2016" /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */,
+		"lib": ["ES2022", "DOM", "DOM.Iterable"],
 
-    /* Language and Environment */
-    "target": "es2016",                                  /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
-    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+		/* Modules */
+		"module": "ES2022" /* Specify what module code is generated. */,
+		"rootDir": "src",
+		"noImplicitOverride": true,
 
-    /* Modules */
-    "module": "ES2022",                                /* Specify what module code is generated. */
-    "rootDir": "src",
-    "noImplicitOverride": true,
+		/* Emit */
+		"sourceMap": true /* Create source map files for emitted JavaScript files. */,
+		// "inlineSourceMap": true,                          /* Include sourcemap files inside the emitted JavaScript. */
+		"noEmit": false /* Disable emitting files from a compilation. */,
+		// "outFile": "./",                                  /* Specify a file that bundles all outputs into one JavaScript file. If 'declaration' is true, also designates a file that bundles all .d.ts output. */
+		"outDir": "dist",
 
-    /* Emit */
-    "sourceMap": true,                                /* Create source map files for emitted JavaScript files. */
-    // "inlineSourceMap": true,                          /* Include sourcemap files inside the emitted JavaScript. */
-    "noEmit": false,                                   /* Disable emitting files from a compilation. */
-    // "outFile": "./",                                  /* Specify a file that bundles all outputs into one JavaScript file. If 'declaration' is true, also designates a file that bundles all .d.ts output. */
-    "outDir": "dist",
+		"esModuleInterop": true /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables 'allowSyntheticDefaultImports' for type compatibility. */,
+		// "preserveSymlinks": true,                         /* Disable resolving symlinks to their realpath. This correlates to the same flag in node. */
+		"forceConsistentCasingInFileNames": true /* Ensure that casing is correct in imports. */,
 
-    "esModuleInterop": true,                             /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables 'allowSyntheticDefaultImports' for type compatibility. */
-    // "preserveSymlinks": true,                         /* Disable resolving symlinks to their realpath. This correlates to the same flag in node. */
-    "forceConsistentCasingInFileNames": true,            /* Ensure that casing is correct in imports. */
+		/* Type Checking */
+		"strict": true /* Enable all strict type-checking options. */,
+		"noImplicitAny": true /* Enable error reporting for expressions and declarations with an implied 'any' type. */,
+		"skipLibCheck": true /* Skip type checking all .d.ts files. */,
 
-    /* Type Checking */
-    "strict": true,                                      /* Enable all strict type-checking options. */
-    "noImplicitAny": true,                            /* Enable error reporting for expressions and declarations with an implied 'any' type. */
-    "skipLibCheck": true,                                 /* Skip type checking all .d.ts files. */
-
-    "composite": true
-  },
-  "include": [
-    "src/**/*"
-  ],
-  "exclude": [
-    "src/contentScript"
-  ]
+		"composite": true
+	},
+	"include": ["src/**/*"],
+	"exclude": ["src/contentScript"]
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,6 +1,6 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
-import path from 'path'
+import path from 'node:path'
 
 export default defineConfig({
 	plugins: [react()],

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,6 +1,6 @@
-import { defineConfig } from 'vite'
-import react from '@vitejs/plugin-react'
 import path from 'node:path'
+import react from '@vitejs/plugin-react'
+import { defineConfig } from 'vite'
 
 export default defineConfig({
 	plugins: [react()],

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,30 +3,30 @@ import react from '@vitejs/plugin-react'
 import { defineConfig } from 'vite'
 
 export default defineConfig({
-	plugins: [react()],
-	build: {
-		emptyOutDir: false,
-		rollupOptions: {
-			input: './src/contentScript/index.ts',
-			output: {
-				entryFileNames: (chunkInfo) => {
-					return path.relative(
-						'src',
-						chunkInfo.facadeModuleId?.replace(/\.[^/.]+$/, '.js') ?? 'index.js',
-					)
-				},
-				assetFileNames: (assetInfo) => {
-					const isCss = assetInfo.name?.endsWith('.css')
-					const isContentScript = assetInfo.name?.startsWith('src/contentScript')
+  plugins: [react()],
+  build: {
+    emptyOutDir: false,
+    rollupOptions: {
+      input: './src/contentScript/index.ts',
+      output: {
+        entryFileNames: (chunkInfo) => {
+          return path.relative(
+            'src',
+            chunkInfo.facadeModuleId?.replace(/\.[^/.]+$/, '.js') ?? 'index.js',
+          )
+        },
+        assetFileNames: (assetInfo) => {
+          const isCss = assetInfo.name?.endsWith('.css')
+          const isContentScript = assetInfo.name?.startsWith('src/contentScript')
 
-					if (isCss && !isContentScript) {
-						return 'contentScript/index.css'
-					}
+          if (isCss && !isContentScript) {
+            return 'contentScript/index.css'
+          }
 
-					// default
-					return 'assets/[name]-[hash][extname]'
-				},
-			},
-		},
-	},
+          // default
+          return 'assets/[name]-[hash][extname]'
+        },
+      },
+    },
+  },
 })

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,35 +1,32 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
-import path from 'path';
+import path from 'path'
 
 export default defineConfig({
-  plugins: [
-    react(),
-  ],
-  build:{
-    emptyOutDir: false,
-    rollupOptions: {
-      input: './src/contentScript/index.ts',
-      output: {
-        entryFileNames: (chunkInfo) => {
-          return path.relative(
-            'src',
-            chunkInfo.facadeModuleId?.replace(/\.[^/.]+$/, ".js") ?? 'index.js'
-          );
-        },
-        assetFileNames: (assetInfo) => {
-          const isCss = assetInfo.name?.endsWith('.css');
-          const isContentScript = assetInfo.name?.startsWith('src/contentScript');
+	plugins: [react()],
+	build: {
+		emptyOutDir: false,
+		rollupOptions: {
+			input: './src/contentScript/index.ts',
+			output: {
+				entryFileNames: (chunkInfo) => {
+					return path.relative(
+						'src',
+						chunkInfo.facadeModuleId?.replace(/\.[^/.]+$/, '.js') ?? 'index.js',
+					)
+				},
+				assetFileNames: (assetInfo) => {
+					const isCss = assetInfo.name?.endsWith('.css')
+					const isContentScript = assetInfo.name?.startsWith('src/contentScript')
 
-          if (isCss && !isContentScript) {
-            return 'contentScript/index.css'
-          }
+					if (isCss && !isContentScript) {
+						return 'contentScript/index.css'
+					}
 
-          // default
-          return 'assets/[name]-[hash][extname]'
-        }
-      },
-    }
-  }
+					// default
+					return 'assets/[name]-[hash][extname]'
+				},
+			},
+		},
+	},
 })
-


### PR DESCRIPTION
closed #11 

## 배경
관성대로 eslint + prettier로 설정하려 했으나, [eslint flat config](https://eslint.org/blog/2022/08/new-config-system-part-2/)에서 기존 프로젝트들에서 사용하던 prettier의 기존 설정 그대로 마이그레이션 불가능.

간단한 lint + formatter만 지원해 주면 되는데 굳이 eslint를 고수할 필요를 못 느낌. 

따라서 [biome]()을 경험해 보고자 함

## 요구사항
- ~~src 폴더 하위에 적용되어야 한다.~~
  - node_modules 및 dist를 제외한 모든 파일 적용 
 
## 추가 작업 사항
- 기본 포매터 biome 적용
- 저장시 import sorting 적용되도록 설정
