### PR TITLE
feature: heading 수집 필터링 추가

### DIFF
--- a/src/contentScript/application/src/features/FloatingToc/Toc.tsx
+++ b/src/contentScript/application/src/features/FloatingToc/Toc.tsx
@@ -1,5 +1,4 @@
 import { motion } from 'framer-motion'
-import { useRef } from 'react'
 import { twMerge } from 'tailwind-merge'
 import { SwitchCase } from '../../components/SwitchCase'
 import { useHeadings, useTocHighlight } from './toc.hook'
@@ -13,14 +12,11 @@ export const Toc = (props: Props) => {
   const { headings, hasParsedHeading, parsedHeadings } = useHeadings()
   const { activeId, changeActiveId } = useTocHighlight({ headings: headings ?? [] })
 
-  const scrollAreaRef = useRef<HTMLDivElement>(null)
-
   return (
     <motion.nav
       layout
       onClick={props.onTap}
       className="h-[calc(100%-55px)] w-full overflow-auto pt-[15px] pb-[10px] outline-none"
-      ref={scrollAreaRef}
     >
       <SwitchCase
         value={hasParsedHeading ? 'fill' : 'empty'}

--- a/src/contentScript/application/src/features/FloatingToc/toc.const.ts
+++ b/src/contentScript/application/src/features/FloatingToc/toc.const.ts
@@ -1,1 +1,6 @@
 export const TOC_TITLE_ID = 'toc-title'
+
+export const HEADING_SELECTOR_ORDERER = [
+  'main',
+  'body article'
+] as const

--- a/src/contentScript/application/src/features/FloatingToc/toc.const.ts
+++ b/src/contentScript/application/src/features/FloatingToc/toc.const.ts
@@ -4,3 +4,4 @@ export const HEADING_SELECTOR_ORDERER = [
   'main',
   'body article'
 ] as const
+export const NONE_BREAKING_SPACE_UNICODE = '\u00A0'

--- a/src/contentScript/application/src/features/FloatingToc/toc.hook.ts
+++ b/src/contentScript/application/src/features/FloatingToc/toc.hook.ts
@@ -1,13 +1,13 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { throttle } from '../../utils/throttle'
-import { TOC_TITLE_ID } from './toc.const'
 import { getAllHeadings, parseHeadingInfo } from './toc.utils'
 
 export const useHeadings = () => {
   const [headings, setHeadings] = useState<Array<HTMLHeadingElement> | null>(null)
 
   useEffect(() => {
-    const headings = Array.from(getAllHeadings()).filter((heading) => heading.id !== TOC_TITLE_ID)
+    const headings = getAllHeadings()
+    
     setHeadings(headings)
   }, [])
 

--- a/src/contentScript/application/src/features/FloatingToc/toc.utils.ts
+++ b/src/contentScript/application/src/features/FloatingToc/toc.utils.ts
@@ -1,13 +1,23 @@
-import { TOC_TITLE_ID } from './toc.const';
+import { HEADING_SELECTOR_ORDERER, TOC_TITLE_ID } from './toc.const';
 import type { Area, HeadingInfo } from './toc.type'
 
+const getHeadingContainer = () => {
+  for (const selector of HEADING_SELECTOR_ORDERER)  {
+    const container = document.querySelector(selector)
+
+    if (container) {
+      return container
+    }
+  }
+
+  return document
+}
+
 export const getAllHeadings = () => {
-  const main = document.querySelector('main')
-
-  const headings = main
-    ? main.querySelectorAll<HTMLHeadingElement>('h1, h2, h3, h4')
-    : document.querySelectorAll<HTMLHeadingElement>('h1, h2, h3, h4')
-
+  const container = getHeadingContainer()
+  const headings = container
+    .querySelectorAll<HTMLHeadingElement>('h1, h2, h3, h4')
+    
   return Array.from(headings)
 }
 

--- a/src/contentScript/application/src/features/FloatingToc/toc.utils.ts
+++ b/src/contentScript/application/src/features/FloatingToc/toc.utils.ts
@@ -1,4 +1,4 @@
-import { HEADING_SELECTOR_ORDERER, TOC_TITLE_ID } from './toc.const';
+import { HEADING_SELECTOR_ORDERER, NONE_BREAKING_SPACE_UNICODE, TOC_TITLE_ID } from './toc.const';
 import type { Area, HeadingInfo } from './toc.type'
 
 const getHeadingContainer = () => {
@@ -22,9 +22,10 @@ export const getAllHeadings = () => {
 }
 
 const filterHeadingList = (headings: Array<Element>)=> {
-    return headings
-      .filter((heading) => heading.id !== TOC_TITLE_ID)
-      .filter(heading => heading.textContent !== '')
+  return headings
+    .filter((heading) => heading.id !== TOC_TITLE_ID)
+    .filter(heading => heading.textContent !== '')
+    .filter(heading => heading.textContent !== NONE_BREAKING_SPACE_UNICODE)
 }
 
 export const parseHeadingInfo = (headings: Array<Element>): HeadingInfo[] => {

--- a/src/contentScript/application/src/features/FloatingToc/toc.utils.ts
+++ b/src/contentScript/application/src/features/FloatingToc/toc.utils.ts
@@ -1,3 +1,4 @@
+import { TOC_TITLE_ID } from './toc.const';
 import type { Area, HeadingInfo } from './toc.type'
 
 export const getAllHeadings = () => {
@@ -7,15 +8,18 @@ export const getAllHeadings = () => {
     ? main.querySelectorAll<HTMLHeadingElement>('h1, h2, h3, h4')
     : document.querySelectorAll<HTMLHeadingElement>('h1, h2, h3, h4')
 
-  return headings
+  return Array.from(headings)
+}
+
+const filterHeadingList = (headings: Array<Element>)=> {
+    return headings
+      .filter((heading) => heading.id !== TOC_TITLE_ID)
+      .filter(heading => heading.textContent !== '')
 }
 
 export const parseHeadingInfo = (headings: Array<Element>): HeadingInfo[] => {
-  headings.forEach((heading, index) => {
-    heading.id = `toc-heading-${index}`
-  })
-
-  const info: HeadingInfo[] = [...headings]
+  const filteredHeadingList = filterHeadingList(headings)
+  const info: HeadingInfo[] = filteredHeadingList
     .map((heading, index) => {
       const [_, level] = [...heading.tagName]
 
@@ -25,7 +29,11 @@ export const parseHeadingInfo = (headings: Array<Element>): HeadingInfo[] => {
         level: Number(level),
       }
     })
-    .filter((headingInfo) => headingInfo.text !== '')
+
+    filteredHeadingList.forEach((heading, index) => {
+      heading.id = `toc-heading-${index}`
+    })
+    
 
   return info
 }

--- a/src/contentScript/application/src/features/FloatingToc/toc.utils.ts
+++ b/src/contentScript/application/src/features/FloatingToc/toc.utils.ts
@@ -23,6 +23,9 @@ export const getAllHeadings = () => {
 
 const filterHeadingList = (headings: Array<Element>)=> {
   return headings
+    .filter(headings => {
+      return !headings.closest('header') && !headings.closest('footer')
+    })
     .filter((heading) => heading.id !== TOC_TITLE_ID)
     .filter(heading => heading.textContent !== '')
     .filter(heading => heading.textContent !== NONE_BREAKING_SPACE_UNICODE)


### PR DESCRIPTION
## 목적
- 더 정확한 본문의 heading 태그 수집

## 문제와 해결

### header, footer 태그의 heading 태그가 수집되는 문제
[feat(filterHeadingList): header, footer 필터링 추가](https://github.com/SaeWooKKang/Floating-Table-of-Contents/commit/facb2202aa7b1ecafa8339bb6b62098f8e13aa4f)하여 해결

### header 태그 수집 우선순위 지정 추가
추후 우선순위 추가시 단일 상수만 변경하도록 리팩토링
 - [refactor: heading container 함수로 분리 및 selector 추가](https://github.com/SaeWooKKang/Floating-Table-of-Contents/commit/4b838ee10d25a1442879223e72bb982c5c331104)
- 해당 작업으로 개선된 페이지
  - medium 포스팅

### 공백이 heading 리스트에 노출되는 문제 수정
- 해당 작업으로 개선된 페이지
  - https://aws.amazon.com/ko/compare/the-difference-between-https-and-http/